### PR TITLE
Murf fixes for getting all block ref counts and trying to optimize further

### DIFF
--- a/src/indexer.ts
+++ b/src/indexer.ts
@@ -2,61 +2,105 @@ import {App, LinkCache, EmbedCache, renderResults} from "obsidian"
 import {CountBlockReferences, BlockRefs} from "./types"
 
 const index = {}
+const pages = {}
 
 export function getIndex() {
     return Object.assign({}, index)
 }
 
-export function updateIndex({update}) {
-    const updateKeys = Object.keys(update)
-    updateKeys.forEach((key) => {
-        index[key] = update[key]
+export function updateIndex() {
+    //console.log('updateIndex()')
+    Object.entries(index).forEach(eachItem => {
+        index[eachItem[0]].count = 0;
+        index[eachItem[0]].references.clear();
     })
+    Object.entries(pages).forEach(eachPage => {
+        eachPage[1].embeds.forEach(embed => {
+            const id = `${embed[3]}^${embed[0]}`;
+            if (index[id]) {
+                index[id].count++
+                index[id].references.add({ file: embed[1], line: embed[2] })
+            }
+        })
+        eachPage[1].links.forEach(link => {
+            const id = `${link[3]}^${link[0]}`;
+            if (index[id]) {
+                index[id].count++
+                index[id].references.add({ file: link[1], line: link[2] })
+            }
+        })
+    })
+    //console.log(index);
 }
 
-export function indexBlockReferences({ app }: {app: App}) {
+export function indexBlockReferences({ app }: { app: App }) {
+    console.log('Full initial index!')
     console.time("index")
     const files = app.vault.getMarkdownFiles()
     files.forEach(file => {
-        const {blocks, links, embeds} = app.metadataCache.getFileCache(file) || {}
-        buildIndexObjects({blocks, embeds, links, file})
-
+        const { blocks, links, embeds } = app.metadataCache.getFileCache(file) || {}
+        buildIndexObjects({ blocks, embeds, links, file })
     })
+    updateIndex()
     console.timeEnd("index")
 }
 
 export function buildIndexObjects({blocks, embeds, links, file}) {
-    const update = {}
+    if (pages[file.path]) { delete pages[file.path] }
+
     if (blocks) {
         Object.values(blocks).forEach((block) => {
-            update[block.id] = {
+            const newid = `${file.basename}^${block.id}`;
+            index[newid] = {
                 count: 0,
-                id: block.id,
+                id: newid,
                 file: file,
                 references: new Set()
             }
-            
         })
     }
+    let foundEmbeds = [];
     if (embeds) {
         embeds.forEach(embed => {
             const split = embed.link.split("^")
             const id = split[1]
-            if (id && update[id]) {
-                update[id].count++
-                update[id].references.add({file, line: embed.position.start.line})
+            if (id) {
+                const page = (split[0].split("#")[0] ? split[0].split("#")[0] : file.basename)
+                foundEmbeds.push(
+                    [
+                        id,
+                        file,
+                        embed.position.start.line,
+                        page
+                    ]
+                )
             }
         })
     }
+
+    let foundLinks = [];
     if (links) {
         links.forEach(link => {
             const split = link.link.split("^")
             const id = split[1]
-            if (id && update[id]) {
-                update[id].count++
-                update[id].references.add({file, line: link.position.start.line})
+            if (id) {
+                const page = (split[0].split("#")[0] ? split[0].split("#")[0] : file.basename)
+                foundLinks.push(
+                    [
+                        id,
+                        file,
+                        link.position.start.line,
+                        page
+                    ]
+                )
             }
         })
     }
-    updateIndex({update})
+
+    if (foundEmbeds.length > 0 || foundLinks.length > 0) {
+        pages[file.path] = {
+            embeds: foundEmbeds,
+            links: foundLinks
+        }
+    }
 }

--- a/src/indexer.ts
+++ b/src/indexer.ts
@@ -4,11 +4,7 @@ import {CountBlockReferences, BlockRefs} from "./types"
 const index = {}
 
 export function getIndex() {
-<<<<<<< HEAD
-    return index
-=======
     return Object.assign({}, index)
->>>>>>> move-indexing
 }
 
 export function updateIndex({update}) {


### PR DESCRIPTION
Block ref counts should be accurate now. The problem was previously you were grabbing the blocks, embeds, and links at the same time and building the {index} but depending on processing order if the file with the source block wasn't processed yet then the file with the block refs wasn't going to match an item in the {index} so therefore a lot of blocks with a 0 for block ref counts.

There still is the problem of the block counter not updating visually because the markdown post processor doesn't re-initiate unless that specific section of the block changes or you leave the page and reload it in the pane. We need to have the html element create table function firing from meta cache updates instead of still just triggered from the markdown post processor.

Can we run dom processing with the metacache update each time to find the HTML element(s) of block refs on the active pane and update the counter? The index will be up to date, but the html is just not being re-rendered/processed.