### PR TITLE
Murf addBlockReferences() function rewrite and fixed transclusion counter

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "cSpell.words": [
+        "offref"
+    ]
+}

--- a/src/indexer.ts
+++ b/src/indexer.ts
@@ -8,6 +8,10 @@ export function getIndex(): Index {
     return Object.assign({}, index)
 }
 
+export function getPages(): Pages {
+    return Object.assign({}, pages)
+}
+
 export function updateIndex(): void {
     //console.log('updateIndex()')
     Object.keys(index).forEach(key => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,7 +21,7 @@ export default class BlockRefCounter extends Plugin {
             const {blocks, embeds, links} = this.app.metadataCache.getFileCache(file)
             buildIndexObjects({ blocks, embeds, links, file })
             updateIndex()
-            createPreviewView({app: this.app})
+            //createPreviewView({app: this.app})
         })
 
         this.layoutChange = this.app.workspace.on("layout-change", () => {
@@ -35,7 +35,7 @@ export default class BlockRefCounter extends Plugin {
         })
 
         this.registerMarkdownPostProcessor((val, ctx) => {
-            addBlockReferences({app: this.app, ctx, val})
+            //addBlockReferences({app: this.app, ctx, val})
         })
   
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -63,15 +63,18 @@ function createPreviewView({ leaf, app }: { leaf?: WorkspaceLeaf, app: App }, ca
     const sourcePath = view.file?.path
     const mdCache = app.metadataCache.getCache(sourcePath)
     const { listItems, sections } = mdCache || {}
-    const listSections = sections.filter(section => section.type === "list").map(section => {
-        const items: ListItemCache[] = []
-        listItems.forEach(item => {
-            if (item.position.start.line >= section.position.start.line && item.position.start.line <= section.position.end.line) {
-                items.push(item)
-            }
+    let listSections: any
+    if (sections && listItems) {
+        listSections = sections.filter(section => section.type === "list").map(section => {
+            const items: ListItemCache[] = []
+            listItems.forEach(item => {
+                if (item.position.start.line >= section.position.start.line && item.position.start.line <= section.position.end.line) {
+                    items.push(item)
+                }
+            })
+            return { section, items }
         })
-        return { section, items }
-    })
+    }
 
     const mdSections = view.previewMode?.renderer.sections
     if (sourcePath && mdSections) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -126,7 +126,7 @@ function addBlockReferences({ app, ctx, val, mdCache, listSections, actView }: A
                 if (listItems && listElements.length > 0) {
                     listSections.forEach((section) => {
                         section.items.forEach((listItem, index) => {
-                            if (listItem.id === eachBlock.id && lineStart === section.section.position.start.line) {
+                            if (listItem.id === eachEmbed.id && lineStart === section.section.position.start.line) {
                                 if (listElements.item(index)) {
                                     createButtonElement({ app, blockRefs: blockRefs[myId], val: listElements.item(index) })
                                 }
@@ -148,7 +148,7 @@ function addBlockReferences({ app, ctx, val, mdCache, listSections, actView }: A
                 if (listItems && listElements.length > 0) {
                     listSections.forEach((section) => {
                         section.items.forEach((listItem, index) => {
-                            if (listItem.id === eachBlock.id && lineStart === section.section.position.start.line) {
+                            if (listItem.id === eachLink.id && lineStart === section.section.position.start.line) {
                                 if (listElements.item(index)) {
                                     createButtonElement({ app, blockRefs: blockRefs[myId], val: listElements.item(index) })
                                 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -78,17 +78,18 @@ function createPreviewView({ leaf, app }: { leaf?: WorkspaceLeaf, app: App }, ca
 
     const mdSections = view.previewMode?.renderer.sections
     if (sourcePath && mdSections) {
+        const blockRefs = getIndex()
         mdSections.forEach((section: { lineStart: number; lineEnd: number; el: HTMLElement; }) => {
             const lineStart = section.lineStart
             const lineEnd = section.lineEnd
             const val = section.el
             const getSectionInfo = (val: HTMLElement) => ({ val, lineStart, lineEnd, text: "" })
-            addBlockReferences({ app: app, ctx: { getSectionInfo, sourcePath }, val, mdCache: mdCache, listSections: listSections, actView: view })
+            addBlockReferences({ app: app, ctx: { getSectionInfo, sourcePath }, val, mdCache: mdCache, listSections: listSections, actView: view, blockRefs: blockRefs })
         })
     }
 }
 
-function addBlockReferences({ app, ctx, val, mdCache, listSections, actView }: AddBlockReferences): void {
+function addBlockReferences({ app, ctx, val, mdCache, listSections, actView, blockRefs }: AddBlockReferences): void {
     const { lineStart, lineEnd } = ctx.getSectionInfo(val) || {}
     //console.log(`markdownPostProcessor: Ln${lineStart}-${lineEnd}`)
     const { blocks, listItems, headings } = mdCache || {}
@@ -119,7 +120,6 @@ function addBlockReferences({ app, ctx, val, mdCache, listSections, actView }: A
     }
     if (matchedBlock.length > 0) {
         //console.log("addBlockReferences: matchedBlock: Ln-" + lineStart)
-        const blockRefs = getIndex()
         const listElements = val.querySelectorAll("li")
         Object.values(matchedBlock).forEach(eachBlock => {
             const myId = `${actView.file.basename}^${eachBlock.id}`
@@ -141,16 +141,14 @@ function addBlockReferences({ app, ctx, val, mdCache, listSections, actView }: A
         })
     } else if (matchedHeading.length > 0) {
         //console.log("addBlockReferences: matchedHeading: Ln-" + lineStart)
-        const headerRefs = getIndex()
         Object.values(matchedHeading).forEach(eachHead => {
             const myId = `${actView.file.basename}#${eachHead.heading}`
-            if (headerRefs[myId] && headerRefs[myId].count >= 0) {
-                createButtonElement({ app, blockRefs: headerRefs[myId], val })
+            if (blockRefs[myId] && blockRefs[myId].count >= 0) {
+                createButtonElement({ app, blockRefs: blockRefs[myId], val })
             }
         })
     } else if (matchedEmbed.length > 0) {
         //console.log("addBlockReferences: matchedEmbed: Ln-" + lineStart)
-        const blockRefs = getIndex()
         const listElements = val.querySelectorAll("li")
         Object.values(matchedEmbed).forEach(eachEmbed => {
             let myId: string
@@ -177,7 +175,6 @@ function addBlockReferences({ app, ctx, val, mdCache, listSections, actView }: A
         })
     } else if (matchedLink.length > 0) {
         //console.log("addBlockReferences: matchedLink: Ln-" + lineStart)
-        const blockRefs = getIndex()
         const listElements = val.querySelectorAll("li")
         Object.values(matchedLink).forEach(eachLink => {
             let myId: string

--- a/src/main.ts
+++ b/src/main.ts
@@ -118,7 +118,7 @@ function addBlockReferences({ app, ctx, val, mdCache, listSections, actView }: A
         }
     }
     if (matchedBlock.length > 0) {
-        console.log("addBlockReferences: matchedBlock: Ln-" + lineStart)
+        //console.log("addBlockReferences: matchedBlock: Ln-" + lineStart)
         const blockRefs = getIndex()
         const listElements = val.querySelectorAll("li")
         Object.values(matchedBlock).forEach(eachBlock => {
@@ -140,7 +140,7 @@ function addBlockReferences({ app, ctx, val, mdCache, listSections, actView }: A
             }
         })
     } else if (matchedHeading.length > 0) {
-        console.log("addBlockReferences: matchedHeading: Ln-" + lineStart)
+        //console.log("addBlockReferences: matchedHeading: Ln-" + lineStart)
         const headerRefs = getIndex()
         Object.values(matchedHeading).forEach(eachHead => {
             const myId = `${actView.file.basename}#${eachHead.heading}`
@@ -149,7 +149,7 @@ function addBlockReferences({ app, ctx, val, mdCache, listSections, actView }: A
             }
         })
     } else if (matchedEmbed.length > 0) {
-        console.log("addBlockReferences: matchedEmbed: Ln-" + lineStart)
+        //console.log("addBlockReferences: matchedEmbed: Ln-" + lineStart)
         const blockRefs = getIndex()
         const listElements = val.querySelectorAll("li")
         Object.values(matchedEmbed).forEach(eachEmbed => {
@@ -176,7 +176,7 @@ function addBlockReferences({ app, ctx, val, mdCache, listSections, actView }: A
             }
         })
     } else if (matchedLink.length > 0) {
-        console.log("addBlockReferences: matchedLink: Ln-" + lineStart)
+        //console.log("addBlockReferences: matchedLink: Ln-" + lineStart)
         const blockRefs = getIndex()
         const listElements = val.querySelectorAll("li")
         Object.values(matchedLink).forEach(eachLink => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
-import { App, ListItemCache, EventRef, Plugin, TFile, MarkdownPreviewView, WorkspaceLeaf} from "obsidian"
-import { AddBlockReferences, CreateButtonElement, FileRef, } from "./types"
-import { indexBlockReferences, buildIndexObjects, updateIndex, getIndex } from "./indexer"
+import { App, ListItemCache, EventRef, Plugin, TFile, MarkdownPreviewView, WorkspaceLeaf, BlockCache, EmbedCache, LinkCache } from "obsidian"
+import { AddBlockReferences, CreateButtonElement, EmbedOrLinkItem, FileRef, } from "./types"
+import { indexBlockReferences, buildIndexObjects, updateIndex, getIndex, getPages } from "./indexer"
 
 export default class BlockRefCounter extends Plugin {
     private cacheUpdate: EventRef;
@@ -37,7 +37,6 @@ export default class BlockRefCounter extends Plugin {
         this.registerMarkdownPostProcessor((val, ctx) => {
             //addBlockReferences({app: this.app, ctx, val})
         })
-  
     }
 
     onunload(): void {
@@ -52,71 +51,120 @@ export default class BlockRefCounter extends Plugin {
 function createPreviewView({leaf, app}: {leaf?: WorkspaceLeaf, app: App}) {
     const view = leaf ?  leaf.view : app.workspace.activeLeaf.view
     const sourcePath = view.file?.path
-    const sections = view.previewMode?.renderer.sections
-    if (sourcePath && sections) {
-        sections.forEach((section: { lineStart: number; lineEnd: number; el: HTMLElement; }) => {
+    const mdCache = app.metadataCache.getCache(sourcePath)
+    const { listItems, sections } = mdCache || {}
+    const listSections = sections.filter(section => section.type === "list").map(section => {
+        const items: ListItemCache[] = []
+        listItems.forEach(item => {
+            if (item.position.start.line >= section.position.start.line && item.position.start.line <= section.position.end.line) {
+                items.push(item)
+            }
+        })
+        return { section, items }
+    })
+
+    const mdSections = view.previewMode?.renderer.sections
+    if (sourcePath && mdSections) {
+        mdSections.forEach((section: { lineStart: number; lineEnd: number; el: HTMLElement; }) => {
             const lineStart = section.lineStart
             const lineEnd = section.lineEnd
             const val = section.el
-            const getSectionInfo = (val: HTMLElement) => ({val, lineStart, lineEnd, text: ""})
-
-            addBlockReferences({app: app, ctx: {getSectionInfo, sourcePath}, val })
+            const getSectionInfo = (val: HTMLElement) => ({ val, lineStart, lineEnd, text: "" })
+            addBlockReferences({ app: app, ctx: { getSectionInfo, sourcePath }, val, mdCache: mdCache, listSections: listSections, actView: view })
         })
-
     }
-
 }
 
-function addBlockReferences({ app, ctx, val }: AddBlockReferences): void {
+function addBlockReferences({ app, ctx, val, mdCache, listSections, actView }: AddBlockReferences): void {
     const { lineStart, lineEnd } = ctx.getSectionInfo(val) || {}
     //console.log(`markdownPostProcessor: Ln${lineStart}-${lineEnd}`)
-    const { blocks, listItems, sections } = app.metadataCache.getCache(ctx.sourcePath) || {}
+    const { blocks, listItems } = mdCache || {}
+    const pageLinks = getPages();
+    const foundPage = pageLinks[ctx.sourcePath];
+    let matchedBlock: BlockCache[] = []
+    let matchedEmbed: EmbedOrLinkItem[] = []
+    let matchedLink: EmbedOrLinkItem[] = []
+
     if (blocks) {
-        const matchedBlock = Object.values(blocks).find((eachBlock) => { if (eachBlock.position.start.line >= lineStart && eachBlock.position.start.line <= lineEnd) { return true } else { return false } })
-        if (matchedBlock) {
-            console.log("markdownPostProcessor Block Ref section...")
-            const blockRefs = getIndex()
-            const thisFile = app.vault.getAbstractFileByPath(ctx.sourcePath) as TFile
-            const listSections = sections.filter(section => section.type === "list").map(section => {
-                const items: ListItemCache[] = []
-                listItems.forEach(item => {
-                    if (item.position.start.line >= section.position.start.line && item.position.start.line <= section.position.end.line) {
-                        items.push(item)
-                    }
-                })
-                return { section, items }
-            })
-            const listElements = val.querySelectorAll("li")
-
-            Object.values(blocks).forEach((block) => {
-                const myId = `${thisFile.basename}^${block.id}`
-                if (blockRefs[myId] && blockRefs[myId]) {
-                    if (sections) {
-                        sections.forEach(section => {
-                            if (section.id === block.id && lineStart === block.position.start.line) {
-                                createButtonElement({ app, blockRefs: blockRefs[myId], val })
-                            }
-
-                        })
-                    }
-                    if (listItems && listElements.length > 0) {
-                        listSections.forEach((section) => {
-                            section.items.forEach((listItem, index) => {
-                                if (listItem.id === block.id && lineStart === section.section.position.start.line) {
-                                    if (listElements.item(index)) {
-                                        createButtonElement({ app, blockRefs: blockRefs[myId], val: listElements.item(index) })
-                                    }
+        matchedBlock = Object.values(blocks).filter((eachBlock) => {
+            if (eachBlock.position.start.line >= lineStart && eachBlock.position.end.line <= lineEnd) { return true } else { return false }
+        })
+    }
+    if (foundPage && matchedBlock.length === 0) {
+        if (foundPage.embeds) { matchedEmbed = Object.values(foundPage.embeds).filter((eachEmbed) => { if (eachEmbed.pos >= lineStart && eachEmbed.pos <= lineEnd) { return true } else { return false } }) }
+        if (matchedEmbed.length === 0 && foundPage.links) { matchedLink = Object.values(foundPage.links).filter((eachLink) => { if (eachLink.pos >= lineStart && eachLink.pos <= lineEnd) { return true } else { return false } }) }
+    }
+    if (matchedBlock.length > 0) {
+        console.log("addBlockReferences: matchedBlock: Ln-" + lineStart)
+        const blockRefs = getIndex()
+        const listElements = val.querySelectorAll("li")
+        Object.values(matchedBlock).forEach(eachBlock => {
+            const myId = `${actView.file.basename}^${eachBlock.id}`
+            if (blockRefs[myId] && blockRefs[myId].count >= 0) {
+                if (listItems && listElements.length > 0) {
+                    listSections.forEach((section) => {
+                        section.items.forEach((listItem, index) => {
+                            if (listItem.id === eachBlock.id && lineStart === section.section.position.start.line) {
+                                if (listElements.item(index)) {
+                                    createButtonElement({ app, blockRefs: blockRefs[myId], val: listElements.item(index) })
                                 }
-                            })
+                            }
                         })
-                    }
+                    })
+                } else {
+                    createButtonElement({ app, blockRefs: blockRefs[myId], val })
                 }
-            })
-        }
+            }
+        })
+    } else if (matchedEmbed.length > 0) {
+        console.log("addBlockReferences: matchedEmbed: Ln-" + lineStart)
+        const blockRefs = getIndex()
+        const listElements = val.querySelectorAll("li")
+        Object.values(matchedEmbed).forEach(eachEmbed => {
+            const myId = `${eachEmbed.page}^${eachEmbed.id}`
+            if (blockRefs[myId] && blockRefs[myId].count > 0) {
+                if (listItems && listElements.length > 0) {
+                    listSections.forEach((section) => {
+                        section.items.forEach((listItem, index) => {
+                            if (listItem.id === eachBlock.id && lineStart === section.section.position.start.line) {
+                                if (listElements.item(index)) {
+                                    createButtonElement({ app, blockRefs: blockRefs[myId], val: listElements.item(index) })
+                                }
+                            }
+                        })
+                    })
+                } else {
+                    createButtonElement({ app, blockRefs: blockRefs[myId], val })
+                }
+            }
+        })
+    } else if (matchedLink.length > 0) {
+        console.log("addBlockReferences: matchedLink: Ln-" + lineStart)
+        const blockRefs = getIndex()
+        const listElements = val.querySelectorAll("li")
+        Object.values(matchedLink).forEach(eachLink => {
+            const myId = `${eachLink.page}^${eachLink.id}`
+            if (blockRefs[myId] && blockRefs[myId].count > 0) {
+                if (listItems && listElements.length > 0) {
+                    listSections.forEach((section) => {
+                        section.items.forEach((listItem, index) => {
+                            if (listItem.id === eachBlock.id && lineStart === section.section.position.start.line) {
+                                if (listElements.item(index)) {
+                                    createButtonElement({ app, blockRefs: blockRefs[myId], val: listElements.item(index) })
+                                }
+                            }
+                        })
+                    })
+                } else {
+                    createButtonElement({ app, blockRefs: blockRefs[myId], val })
+                }
+            }
+        })
     }
 }
 
-function createButtonElement({app, blockRefs, val }: CreateButtonElement): void {
+function createButtonElement({ app, blockRefs, val }: CreateButtonElement): void {
+    console.log(`createButtonElement: ${blockRefs.count}: ${blockRefs.file.basename}: ${blockRefs.id}`)
     const existingButton = val.querySelectorAll(".count").item(0)
     const countEl = createEl("button", { cls: "count" })
     countEl.innerText = blockRefs.count.toString()
@@ -132,7 +180,6 @@ function createButtonElement({app, blockRefs, val }: CreateButtonElement): void 
     if (blockRefs.count > 0) {
         val.prepend(countEl)
     }
-
 }
 
 function createTable({app, val, files}: {app: App, val: HTMLElement, files: FileRef[]}) {
@@ -150,7 +197,7 @@ function createTable({app, val, files}: {app: App, val: HTMLElement, files: File
         const row = createEl("tr")
         const noteCell = createEl("td")
         const lineCell = createEl("td")
-        noteCell.appendChild(createEl("a", {cls: "internal-link", href: fileRef.file.path, text: fileRef.file.name.split(".")[0]}))
+        noteCell.appendChild(createEl("a", { cls: "internal-link", href: fileRef.file.path, text: fileRef.file.basename }))
         lineCell.appendChild(createEl("span", {text: lineContent}))
         row.appendChild(noteCell)
         row.appendChild(lineCell)

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { App, MarkdownPostProcessorContext, TFile, BlockCache, LinkCache, EmbedCache  } from "obsidian"
+import { App, MarkdownPostProcessorContext, TFile, BlockCache, LinkCache, EmbedCache, MetadataCache, CachedMetadata, WorkspaceLeaf, View } from "obsidian"
 
 declare module "obsidian" {
   interface View {
@@ -11,6 +11,9 @@ export interface AddBlockReferences {
   app: App
   ctx: MarkdownPostProcessorContext | { sourcePath: string, getSectionInfo: (val: HTMLElement) => void }
   val: HTMLElement
+  mdCache: CachedMetadata
+  listSections: any
+  actView: View
 }
 
 export interface CreateButtonElement {

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,7 @@ export interface AddBlockReferences {
   mdCache: CachedMetadata
   listSections: any
   actView: View
+  blockRefs: Index
 }
 
 export interface CreateButtonElement {

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,6 +37,7 @@ interface IndexItem {
   id: string
   file: TFile
   references: Set<IndexItemReference>
+  type: string
 }
 
 export interface Index {
@@ -48,6 +49,7 @@ export interface EmbedOrLinkItem {
   file: TFile
   pos: number
   page: string
+  type: string
 }
 
 


### PR DESCRIPTION
Should be working nicely EXCEPT one thing... I stopped having the markdownPostProcessor run anything because I think that slows things down because every section then runs the addBlockReferences() function and we'd need to grab the metadatache and index the list items each time it runs for each individual postProcessed block. It does create an issue though where the very first time flipping to preview mode it won't show the block counter. But if you simply click out to another pane and back to it OR if you flip back to edit and then preview again, then they will show. Ideally what we need is a POST post processor of the entire page.... so instead of firing on each block/section being processed by the postProcessor we need something that fires after ALL have been processed on the page so it fires just once after postProcessing is done.