### PR TITLE
Murf updates - Header links working, css updates, other misc

### DIFF
--- a/src/indexer.ts
+++ b/src/indexer.ts
@@ -148,7 +148,7 @@ function buildObjects({ pages }: { pages: Page[] }) {
 
             })
             page.headings && page.headings.forEach((heading) => {
-                if (link.type === "heading" && link.id === heading.key && link.page === heading.page) {
+                if (link.type === "heading" && cleanHeader(link.id) === cleanHeader(heading.key) && link.page === heading.page) {
 
                     const object = { basename: link.file.basename, path: link.file.path, pos: link.pos }
                     if (!isEquivalent(heading.references, object)) {
@@ -182,7 +182,13 @@ function buildLinksAndEmbeds({ pages }: { pages: Page[] }) {
     }, [])
     pages.forEach(page => {
         page.items && page.items.forEach(item => {
-            const ref = allRefs.find(ref => ref.key === item.id && ref.page === item.page)
+            const ref = allRefs.find(ref => {
+                if (item.type === "heading") {
+                    if (cleanHeader(ref.key) === cleanHeader(item.id) && ref.page === item.page) { return true } else { return false }
+                } else {
+                    if (ref.key === item.id && ref.page === item.page) { return true } else { return false }
+                }
+            })
             item.reference = ref && { ...ref, type: "link" }
 
         })
@@ -258,3 +264,6 @@ function isEquivalent(set: Set<Reference>, object: Reference) {
     return equiv
 }
 
+export function cleanHeader(header: string) {
+    return header.replace(/(\[|\]|#|\*)/g, '')
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -101,7 +101,8 @@ export default class BlockRefCounter extends Plugin {
  * @return  {void}
  */
 function createPreviewView({ leaf, app }: { leaf?: WorkspaceLeaf; app: App }) {
-    const view = leaf ? leaf.view : app.workspace.activeLeaf.view
+    const view = leaf ? leaf.view : app.workspace.activeLeaf ? app.workspace.activeLeaf.view : null
+    if (!view) { return }
     const sourcePath = view.file?.path
     // if previewMode exists and has sections, get the sections
     const elements = view.previewMode?.renderer?.sections

--- a/src/main.ts
+++ b/src/main.ts
@@ -365,16 +365,10 @@ function createButtonElement({ app, block, val }: CreateButtonElement): void {
 function createSearchElement({ app, search, block }) {
     const searchElement = search[search.length - 1].view.containerEl
     searchElement.setAttribute("data-block-ref-id", block.key)
-    const query = searchElement.querySelector(".search-input-container")
     const toolbar = searchElement.querySelector(".nav-buttons-container")
-    query.setAttribute("style", "display: none")
     const closeButton = createEl("button", {
         cls: "search-input-clear-button",
     })
-    closeButton.setAttribute(
-        "style",
-        "background: transparent; margin-top: 7px; margin-right: 130px"
-    )
     closeButton.on("click", "button", () => {
         app.workspace.getLeavesOfType("search-ref").forEach((leaf) => {
             const container = leaf.view.containerEl

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,7 +6,7 @@ import {
     Heading,
     AddLinkReferences,
 } from "./types"
-import { indexBlockReferences, getPages } from "./indexer"
+import { indexBlockReferences, getPages, cleanHeader } from "./indexer"
 import { defaultCipherList } from "constants"
 
 /**
@@ -322,12 +322,13 @@ function createButtonElement({ app, block, val }: CreateButtonElement): void {
 
     countEl.on("click", "button", async () => {
         const tempLeaf = app.workspace.getRightLeaf(false)
+        const blockKeyEsc = regexEscape(block.key)
+        const blockPageEsc = regexEscape(block.page)
+        const blockKeyClean = cleanHeader(block.key)
         await tempLeaf.setViewState({
             type: "search-ref",
             state: {
-                //query: `--file:${block.page} /#(\\\^|\\\s)?${block.key}/ OR /(!)?${block.page}#(\\\^)?${block.key}/`,
-                query: `((--file:("${block.page}.md") / \\^${block.key}$/) OR (--file:("${block.page}.md") /#\\^${block.key}\]\]/) OR ("^${block.key}" --/\\[\\[${block.page}#\\^${block.key}\\]\\]/)) OR ((--file:("${block.page}.md") (/#+ ${block.key}$/ OR /\\[\\[#${block.key}\\]\\]/)) OR /\\[\\[${block.page}#${block.key}\\]\\]/)`,
-
+                query: `((--file:("${blockPageEsc}.md") / \\^${blockKeyEsc}$/) OR (--file:("${blockPageEsc}.md") /#\\^${blockKeyEsc}\]\]/) OR ("^${blockKeyEsc}" --/\\[\\[${blockPageEsc}#\\^${blockKeyEsc}\\]\\]/)) OR ((--file:("${blockPageEsc}.md") (/#+ ${blockKeyEsc}$/ OR /\\[\\[#${blockKeyClean}\\]\\]/)) OR /\\[\\[${blockPageEsc}#${blockKeyClean}\\]\\]/)`,
             },
         })
         const search = app.workspace.getLeavesOfType("search-ref")
@@ -397,4 +398,8 @@ function unloadButtons(app: App): void {
     const buttons =
         app.workspace.activeLeaf.containerEl.querySelectorAll("#count")
     buttons && buttons.forEach((button: HTMLElement) => button.remove())
+}
+
+function regexEscape(regexString: string) {
+    return regexString.replace(/(\[|\]|\^|\*)/g, '\\$1')
 }

--- a/styles.css
+++ b/styles.css
@@ -25,3 +25,17 @@
   background-color: transparent;
   color: var(--text-muted);
 }
+
+[data-block-ref-id] .search-input-container, [data-block-ref-id] [aria-label="Match case"], [data-block-ref-id] [aria-label="Explain search term"] {
+  display: none;
+}
+
+[data-block-ref-id] .nav-buttons-container .search-input-clear-button {
+  background: transparent;
+  position: relative;
+  padding: 5px 8px 0 8px;
+  margin: 0 3px 10px 3px;
+  top: unset;
+  right: unset;
+  bottom: 5px;
+}


### PR DESCRIPTION
* Fixed header refs with [[page link]] brackets, `#` tags and `*` (md formatting)... should research further to add more criteria later like for highlights `==` etc. but for now the biggest use case was for pages and tags
* Moved some of the hardcoded styling from the code to the CSS like for hiding the search box
* Added CSS to hide the match case and explain search query buttons
* Fixed a console error on a null activeleaf scenario at startup
* Updated regex.... looks good for block refs and headers now