### PR TITLE
Murf dev - Take care of pipe characters, tweak search element height calcs, and fix search views opening in sidebar

### DIFF
--- a/src/indexer.ts
+++ b/src/indexer.ts
@@ -265,5 +265,5 @@ function isEquivalent(set: Set<Reference>, object: Reference) {
 }
 
 export function cleanHeader(header: string) {
-    return header.replace(/(\[|\]|#|\*)/g, '')
+    return header.replace(/(\[|\]|#|\*)/g, '').replace(/(\|)/g, ' ')
 }

--- a/src/indexer.ts
+++ b/src/indexer.ts
@@ -265,5 +265,5 @@ function isEquivalent(set: Set<Reference>, object: Reference) {
 }
 
 export function cleanHeader(header: string) {
-    return header.replace(/(\[|\]|#|\*)/g, '').replace(/(\|)/g, ' ')
+    return header.replace(/(\[|\]|#|\*|\(|\))/g, '').replace(/(\|)/g, ' ')
 }

--- a/src/indexer.ts
+++ b/src/indexer.ts
@@ -265,5 +265,5 @@ function isEquivalent(set: Set<Reference>, object: Reference) {
 }
 
 export function cleanHeader(header: string) {
-    return header.replace(/(\[|\]|#|\*|\(|\))/g, '').replace(/(\|)/g, ' ')
+    return header.replace(/(\[|\]|#|\*|\(|\))/g, '').replace(/(\||\.)/g, ' ')
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -331,6 +331,8 @@ function createButtonElement({ app, block, val }: CreateButtonElement): void {
 
     countEl.on("click", "button", async () => {
         const tempLeaf = app.workspace.getRightLeaf(false)
+        //Hide the leaf/pane so it doesn't show up in the right sidebar
+        tempLeaf.tabHeaderEl.hide()
         const blockKeyEsc = regexEscape(block.key)
         const blockPageEsc = regexEscape(block.page)
         const blockKeyClean = cleanHeader(block.key)

--- a/src/main.ts
+++ b/src/main.ts
@@ -345,7 +345,7 @@ function createButtonElement({ app, block, val }: CreateButtonElement): void {
         const search = app.workspace.getLeavesOfType("search-ref")
         const searchElement = createSearchElement({ app, search, block })
         let searchHeight: number;
-        if (count === 1) { searchHeight = 200 } else if (count === 2) { searchHeight = 250 } else {
+        if (count === 1) { searchHeight = 225 } else if (count === 2) { searchHeight = 250 } else {
             searchHeight = (count + 1) * 85
             if (searchHeight < 300) { searchHeight = 300 } else if (searchHeight > 600) { searchHeight = 600 }
         }
@@ -420,5 +420,5 @@ function unloadSearchViews(app: App): void {
 }
 
 function regexEscape(regexString: string) {
-    return regexString.replace(/(\[|\]|\^|\*|\||\(|\))/g, '\\$1')
+    return regexString.replace(/(\[|\]|\^|\*|\||\(|\)|\.)/g, '\\$1')
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -342,9 +342,11 @@ function createButtonElement({ app, block, val }: CreateButtonElement): void {
         })
         const search = app.workspace.getLeavesOfType("search-ref")
         const searchElement = createSearchElement({ app, search, block })
-        let searchHeight = (count + 1) * 85
-        if (searchHeight < 300) { searchHeight = 300 }
-        if (searchHeight > 600) { searchHeight = 600 }
+        let searchHeight: number;
+        if (count === 1) { searchHeight = 200 } else if (count === 2) { searchHeight = 250 } else {
+            searchHeight = (count + 1) * 85
+            if (searchHeight < 300) { searchHeight = 300 } else if (searchHeight > 600) { searchHeight = 600 }
+        }
         searchElement.setAttribute("style", "height: " + searchHeight + "px;")
         
         if (!val.children.namedItem("search-ref")) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -420,5 +420,5 @@ function unloadSearchViews(app: App): void {
 }
 
 function regexEscape(regexString: string) {
-    return regexString.replace(/(\[|\]|\^|\*|\|)/g, '\\$1')
+    return regexString.replace(/(\[|\]|\^|\*|\||\(|\))/g, '\\$1')
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -416,5 +416,5 @@ function unloadSearchViews(app: App): void {
 }
 
 function regexEscape(regexString: string) {
-    return regexString.replace(/(\[|\]|\^|\*)/g, '\\$1')
+    return regexString.replace(/(\[|\]|\^|\*|\|)/g, '\\$1')
 }


### PR DESCRIPTION
- Tweaking searchElement height calculation. Make smaller when only 1 or 2 results.
- Add "|" pipe to the regex escape function
- Add "|" pipe to cleanHeader function for aliases. Replaced with a " " space based on how Obsidian handled them.
- Fixed search panes opening up in the right sidebar